### PR TITLE
Fix in the hall script; Added few post build things.

### DIFF
--- a/PlusLevelStudio/Editor/Controllers/RoomEditorController.cs
+++ b/PlusLevelStudio/Editor/Controllers/RoomEditorController.cs
@@ -181,6 +181,7 @@ namespace PlusLevelStudio.Editor
                             int wallsVal = cell.walls;
                             if ((wallsVal & mask) != 0 && !roomAsset.cells.Exists(checkCell => checkCell.position == neighborPos))
                             {
+                                // Debug.Log($"Changed wall cell at ({cell.position.ToInt().ToString()}) | {Convert.ToString(cell.walls, 2).PadLeft(4, '0')} -> {Convert.ToString((byte)(wallsVal & ~mask), 2).PadLeft(4, '0')}");
                                 cell.walls = new Nybble((byte)(wallsVal & ~mask));
                                 cell.coverage &= (PlusCellCoverage)~(int)dir.ToCoverage();
                             }

--- a/PlusLevelStudio/PlusLevelStudio.csproj
+++ b/PlusLevelStudio/PlusLevelStudio.csproj
@@ -85,5 +85,9 @@
       <HintPath>..\Dependencies\UnityEngine.UIModule.dll</HintPath>
     </Reference>
   </ItemGroup>
+  
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Exec Command="copy /y &quot;$(OutputPath)\$(AssemblyName).dll&quot; &quot;C:\Program Files (x86)\Steam\steamapps\common\Baldi's Basics Plus\BepInEx\plugins\newEditor&quot;&#xD;&#xA;copy /y &quot;$(OutputPath)\$(AssemblyName).pdb&quot; &quot;C:\Program Files (x86)\Steam\steamapps\common\Baldi's Basics Plus\BepInEx\plugins\newEditor&quot;" />
+  </Target>
 
 </Project>

--- a/PlusStudioLevelFormat/PlusStudioLevelFormat.csproj
+++ b/PlusStudioLevelFormat/PlusStudioLevelFormat.csproj
@@ -9,4 +9,8 @@
     <None Include="..\.editorconfig" Link=".editorconfig" />
   </ItemGroup>
 
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Exec Command="copy /y &quot;$(OutputPath)\$(AssemblyName).dll&quot; &quot;C:\Program Files (x86)\Steam\steamapps\common\Baldi's Basics Plus\BepInEx\plugins\newEditor&quot;&#xD;&#xA;copy /y &quot;$(OutputPath)\$(AssemblyName).pdb&quot; &quot;C:\Program Files (x86)\Steam\steamapps\common\Baldi's Basics Plus\BepInEx\plugins\newEditor&quot;" />
+  </Target>
+
 </Project>

--- a/PlusStudioLevelLoader/PlusStudioLevelLoader.csproj
+++ b/PlusStudioLevelLoader/PlusStudioLevelLoader.csproj
@@ -66,4 +66,8 @@
 		</Reference>
 	</ItemGroup>
 
+	<Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    	<Exec Command="copy /y &quot;$(OutputPath)\$(AssemblyName).dll&quot; &quot;C:\Program Files (x86)\Steam\steamapps\common\Baldi's Basics Plus\BepInEx\plugins\newEditor&quot;&#xD;&#xA;copy /y &quot;$(OutputPath)\$(AssemblyName).pdb&quot; &quot;C:\Program Files (x86)\Steam\steamapps\common\Baldi's Basics Plus\BepInEx\plugins\newEditor&quot;" />
+  	</Target>
+
 </Project>


### PR DESCRIPTION
- Casted explicitly the `cell.walls & ~mask` as `byte`.
- Added a Debug.Log there to confirm if it is really doing it (it sure is).
- Added bunch of Postbuild events to automatically copy these DLLs and PDB files to whatever you want.